### PR TITLE
Enhancements to coalesced() and group_single_characters()

### DIFF
--- a/dlh_utils/dataframes.py
+++ b/dlh_utils/dataframes.py
@@ -1555,7 +1555,7 @@ def literal_column(df, col_name, literal):
 ###########################################################################
 
 
-def coalesced(df, subset=None, output_col="coalesced_col"):
+def coalesced(df, subset=None, output_col="coalesced_col", drop=False):
     """
     Produces a new column from a supplied dataframe, that contains the first
     non-null value from each row.
@@ -1571,6 +1571,9 @@ def coalesced(df, subset=None, output_col="coalesced_col"):
     output_col : string, default = 'coalesced_col'
       Name of the output column for results of
       the coalesced columns.
+    drop : boolean, default = False
+      If drop = True, the columns that were coalesced 
+      will be dropped from the dataframe.
 
     Returns
     -------
@@ -1604,6 +1607,16 @@ def coalesced(df, subset=None, output_col="coalesced_col"):
     |   1|null|           1 |
     |null|   2|           2 |
     +----+----+-------------+
+
+    > dataframes.coalesced(df3,subset = None, output_col="coalesced_col", drop=True).show()
+
+    +-------------+
+    |coalesced_col|
+    +-------------+
+    |        null |
+    |           1 |
+    |           2 |
+    +-------------+
     """
 
     if subset is None:
@@ -1611,6 +1624,10 @@ def coalesced(df, subset=None, output_col="coalesced_col"):
 
     df = df.withColumn(output_col,
                        F.coalesce(*[F.col(x) for x in subset]))
+    
+    if drop:
+      df = drop_columns(df, subset=subset, drop_duplicates=False)
+
     return df
 
 ##############################################################################

--- a/dlh_utils/standardisation.py
+++ b/dlh_utils/standardisation.py
@@ -394,7 +394,7 @@ def clean_forename(df, subset):
 ##########################################################################
 
 
-def group_single_characters(df, subset=None):
+def group_single_characters(df, subset=None, include_terminals=False):
     """
     Remove spaces between single characters
 
@@ -414,6 +414,13 @@ def group_single_characters(df, subset=None):
       columns. If the user gives a string value it
       is converted to a list of one column.
       It can also take a list of strings.
+    include_terminals : boolean, default = False
+      If False, single characters in the first and last
+      positions will not be grouped; for example, "a bc d" will
+      be returned as "a bc d" without grouping the "a" and "d"
+      If True, single characters at in the first and last
+      positions will be grouped; for example, "a bc d" will
+      be grouped as "abcd"
 
     Returns
     -------
@@ -433,12 +440,16 @@ def group_single_characters(df, subset=None):
     if not isinstance(subset, list):
         subset = [subset]
 
+    regex = r"(?<= \w|^\w|^)[ ]+(?=\w |\w$|$)"
+    if include_terminals:
+      regex += r"|(?<=^\w)[ ]+(?=\w)"   # Initial single letter
+      regex += r"|(?<=\w)[ ]+(?=\w$)"   # Final single letter
+
     for col in subset:
 
         df = (df
               .withColumn(col,
-                          F.regexp_replace(F.col(col),
-                                           "(?<= \\w|^\\w|^) (?=\\w |\\w$|$)", "")
+                          F.regexp_replace(F.col(col), regex, "")
                           )
               )
 

--- a/dlh_utils/tests/test_dataframes.py
+++ b/dlh_utils/tests/test_dataframes.py
@@ -207,10 +207,48 @@ class TestCoalesced(object):
             ["FO+ UR", "four", "four", "FOU  R", 4, "FO+ UR"],
             [None, None, None, None, 5, "5"],
         ]
-        intended_df = spark.createDataFrame(intended_data, intended_schema)
+        intended_df = spark.createDataFrame(
+          intended_data, intended_schema
+          ).select(
+            test_df.columns
+          )
 
         result_df = coalesced(test_df)
         assert_df_equality(intended_df, result_df)
+
+    def test_expected_with_drop(self, spark):
+
+        test_df = spark.createDataFrame(
+            (
+                pd.DataFrame(
+                    {
+                        "lower": ["one", None, "one", "four", None],
+                        "value": [1, 2, 3, 4, 5],
+                        "extra": [None, None, None, "FO+ UR", None],
+                        "lowerNulls": ["one", "two", None, "four", None],
+                        "upperNulls": ["ONE", "TWO", None, "FOU  R", None],
+                    }
+                )
+            )
+        )
+
+        intended_schema = StructType(
+            [
+                StructField("coalesced_col", StringType(), True),
+            ]
+        )
+        intended_data = [
+            ["one"],
+            ["2"],
+            ["one"],
+            ["four"],
+            ["5"]
+        ]
+        intended_df = spark.createDataFrame(intended_data, intended_schema)
+
+        result_df = coalesced(test_df, drop=True)
+        assert_df_equality(intended_df, result_df)
+
 
 
 #################################################################

--- a/dlh_utils/tests/test_standardisation.py
+++ b/dlh_utils/tests/test_standardisation.py
@@ -616,9 +616,9 @@ class TestGroupSingleCharacters(object):
             (
                 pd.DataFrame(
                     {
-                        "before1": [None, "", "-t-h r e e", "four", "f i v e"],
-                        "before2": [None, "", "-t-h r e e", "four", "f i v e"],
-                        "after": [None, "", "-t-h ree", "four", "five"],
+                        "before1": [None, "", "-t-h r e e", "four", "f i v e", "six ", " seven", "eigh t", "n ine", "t  e    n", "e leve n"],
+                        "before2": [None, "", "-t-h r e e", "four", "f i v e", "six ", " seven", "eigh t", "n ine", "t  e    n", "e leve n"],
+                        "after": [None, "", "-t-h ree", "four", "five", "six ", " seven", "eigh t", "n ine", "ten", "e leve n"],
                     }
                 )
             )
@@ -628,15 +628,46 @@ class TestGroupSingleCharacters(object):
             (
                 pd.DataFrame(
                     {
-                        "before1": [None, "", "-t-h ree", "four", "five"],
-                        "before2": [None, "", "-t-h r e e", "four", "f i v e"],
-                        "after": [None, "", "-t-h ree", "four", "five"],
+                        "before1": [None, "", "-t-h ree", "four", "five", "six ", " seven", "eigh t", "n ine", "ten", "e leve n"],
+                        "before2": [None, "", "-t-h r e e", "four", "f i v e", "six ", " seven", "eigh t", "n ine", "t  e    n", "e leve n"],
+                        "after": [None, "", "-t-h ree", "four", "five", "six ", " seven", "eigh t", "n ine", "ten", "e leve n"],
+                    }
+                )
+            )
+        )
+        result_df = group_single_characters(test_df, subset="before1")
+        assert_df_equality(intended_df, result_df)
+
+    def test_expected_include_terminals(self, spark):
+
+        test_df = spark.createDataFrame(
+            (
+                pd.DataFrame(
+                    {
+                        "before1": [None, "", "-t-h r e e", "four", "f i v e", "six ", " seven", "eigh t", "n ine", "t  e    n", "e leve n"],
+                        "before2": [None, "", "-t-h r e e", "four", "f i v e", "six ", " seven", "eigh t", "n ine", "t  e    n", "e leve n"],
+                        "after": [None, "", "-t-h ree", "four", "five", "six ", " seven", "eight", "nine", "ten", "eleven"],
                     }
                 )
             )
         )
 
-        result_df = group_single_characters(test_df, subset="before1")
+        intended_df = spark.createDataFrame(
+            (
+                pd.DataFrame(
+                    {
+                        "before1": [None, "", "-t-h ree", "four", "five", "six ", " seven", "eight", "nine", "ten", "eleven"],
+                        "before2": [None, "", "-t-h r e e", "four", "f i v e", "six ", " seven", "eigh t", "n ine", "t  e    n", "e leve n"],
+                        "after": [None, "", "-t-h ree", "four", "five", "six ", " seven", "eight", "nine", "ten", "eleven"],
+                    }
+                )
+            )
+        )
+        result_df = group_single_characters(
+          test_df, 
+          subset="before1", 
+          include_terminals=True
+        )
         assert_df_equality(intended_df, result_df)
 
 


### PR DESCRIPTION
Changed coalesced() to add option to drop the coalesced columns (default remains not to drop them). Changed group_single_characters() to work properly when a character is separated from the others by multiple spaces. Also added the option include_terminals which, if set to True, will group single characters at the beginning or end of the string; these are not grouped by default. For example, "c och r an e" is grouped as "c ochran e" with include_terminals = False (this is the previous behaviour) or as "cochrane" with include_terminals = True.

Unit tests for both have also been updated.