### PR TITLE
Fix a failing unit test in TestCoalesced

### DIFF
--- a/dlh_utils/tests/test_dataframes.py
+++ b/dlh_utils/tests/test_dataframes.py
@@ -235,9 +235,9 @@ class TestCoalesced(object):
         )
         intended_data = [
             ["one"],
-            ["2"],
+            ["two"],
             ["one"],
-            ["four"],
+            ["FO+ UR"],
             ["5"]
         ] 
         intended_df = spark.createDataFrame(intended_data, intended_schema)


### PR DESCRIPTION
The intended dataframe in TestCoalesced.test_expected_drop now agrees with the one in TestCoalesced.test_expected and the test passes.