### PR TITLE
Change to filter_window to preserve the data type of the target colum…

### DIFF
--- a/dlh_utils/dataframes.py
+++ b/dlh_utils/dataframes.py
@@ -1460,38 +1460,27 @@ def filter_window(df, filter_window, target, mode, value=None, condition=True):
                   )
 
     if mode in ['min', 'max']:
-
+      
+        dt_target = [dtype for name, dtype in df.dtypes if name == target][0]
+        df = window(df, filter_window, target, mode, alias='value')
+        df = st.fill_nulls(df, fill='<<<>>>', subset=['value']+[target])
+        
         if condition:
-
-            df = window(df, filter_window, target, mode, alias='value')
-
-            df = st.fill_nulls(df, fill='<<<>>>', subset=['value']+[target])
-
             df = (df
                   .where(F.col(target) == F.col('value'))
                   .drop('value')
                   )
-
-            df = (st.standardise_null(df=df,
-                                      replace="^<<<>>>$",
-                                      subset=target)
-                  )
-
         else:
-
-            df = window(df, filter_window, target, mode, alias='value')
-
-            df = st.fill_nulls(df, fill='<<<>>>', subset=['value']+[target])
-
             df = (df
                   .where(F.col(target) != F.col('value'))
                   .drop('value')
                   )
-
-            df = (st.standardise_null(df=df,
-                                      replace="^<<<>>>$",
-                                      subset=target)
-                  )
+            
+        df = (st.standardise_null(df=df,
+                                  replace="^<<<>>>$",
+                                  subset=target)
+              )
+        df = df.withColumn(target, F.col(target).cast(dt_target))
 
     return df
 

--- a/dlh_utils/tests/test_dataframes.py
+++ b/dlh_utils/tests/test_dataframes.py
@@ -889,7 +889,7 @@ class TestFilterWindow(object):
         )
 
         intended_df2 = spark.createDataFrame(
-            (pd.DataFrame({"col1": ["d", "c"], "col2": ["1", "2"]}))
+            (pd.DataFrame({"col1": ["d", "c"], "col2": [1, 2]}))
         )
         result_df2 = filter_window(test_df2, "col1", "col2", "max", condition=False)
 


### PR DESCRIPTION
The main change here is l.1464 and l.1483, where we respectively store and then re-apply the original datatype of the column named in `target`. I also took the opportunity to move some duplicated code out of the if...else... statements.

The unit test now has integers (the original data type) in `intended_df` instead of strings.