### PR TITLE
Pre commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+# here we can set config params for flake8
+# To override the maximum line length check e.g. max-line-length = 100
+# to exclude certain files/directories exclude = .github,.git,docs/source/conf.py,old,build,dist
+# to ignore a specific error on a specific line of code (at the end of a line of code outside of this file) use e.g. # noqa: E731
+# to ignore a specific error across all files (like the annoying pyspark module not found error) specify that here e.g. ignore = E402

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ pip3 -U install dlh_utils
 ## Demo
 For a worked demonstration notebook of these functions being applied within a data linkage context, head over to our [separate demo repository](https://github.com/anthonye93/dlh_utils_demo)
 
+## Contributing
+
+This repository adheres to pep8 coding standards. These can be automatically checked for when you're making new commits by the repository's pre-commit hooks. To get this working:
+* `pip install` both 'flake8' and 'pre-commit'
+* install the git hook scripts `pre-commit install`
+* When adding new git commits, the pre-commit hooks will now run and make suggestions needed to adhere to pep8 code standards
+
 ## Common issues
 
 ### When using the jaro/jaro_winkler functions the error "no module called Jellyfish found" is thrown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,13 @@ pandas = ">=0.20.3"
 importlib_metadata =  "^4.8.3"
 
 [tool.poetry.group.dev.dependencies]
+flake8 = "^6.0.0"
 pyspark = "^2.4.0"
 py4j = "^0.10.7"
 pytest = "^7.0"
 chispa = "^0.9.2"
 black = "^22.8.0"
+pre-commit = "^3.2.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Have added docs for team use to readme and configuration docs and examples to .flake8. This *could* replace the pylint workflow - if the team all install the pre-commit hooks! It's a different and linting-forward way of working so see how you get on with it, it may not be for everyone