### PR TITLE
Deterministic linkage changes

### DIFF
--- a/dlh_utils/linkage.py
+++ b/dlh_utils/linkage.py
@@ -1336,7 +1336,7 @@ def deterministic_linkage(df_l, df_r, id_l, id_r, matchkeys, out_dir):
                   ).count()
     # initial count of matches
     count = 0
-    
+
     for index, matchkey in enumerate(matchkeys, 1):
 
         if index == 1:
@@ -1345,23 +1345,23 @@ def deterministic_linkage(df_l, df_r, id_l, id_r, matchkeys, out_dir):
             )
             # writes first matchkey to parquet
             if use_parquet:
-              ut.write_format(
-                match_data,
-                'parquet',
-                f"{out_dir}/linked_identifiers",
-                mode='overwrite'
-              )
+                ut.write_format(
+                  match_data,
+                  'parquet',
+                  f"{out_dir}/linked_identifiers",
+                  mode='overwrite'
+                )
             else:
-              out_df = match_data
+                out_df = match_data
 
         else:
             # reads previous matches
             # used in left anti join to ignore matched records
             if use_parquet:
-              matches = ut.read_format('parquet',
+                matches = ut.read_format('parquet',
                                        f"{out_dir}/linked_identifiers")
             else:
-              matches = out_df
+                matches = out_df
 
             last_count = count
             count = matches.count()
@@ -1379,21 +1379,20 @@ def deterministic_linkage(df_l, df_r, id_l, id_r, matchkeys, out_dir):
                 id_l, id_r, matchkey, index
             )
             if use_parquet:
-              ut.write_format(
-                match_data,
-                'parquet',
-                f"{out_dir}/linked_identifiers",
-                mode='append'
-              )
+                ut.write_format(
+                  match_data,
+                  'parquet',
+                  f"{out_dir}/linked_identifiers",
+                  mode='append'
+                )
             else:
-              out_df = out_df.union(match_data)
+                out_df = out_df.union(match_data)
 
     # reads and returns final matches
     if use_parquet:
-      matches = ut.read_format('parquet',
-                               f"{out_dir}/linked_identifiers")
+        matches = ut.read_format('parquet', f"{out_dir}/linked_identifiers")
     else:
-      matches = out_df
+        matches = out_df
 
     last_count = count
     count = matches.count()

--- a/dlh_utils/tests/test_linkage.py
+++ b/dlh_utils/tests/test_linkage.py
@@ -12,7 +12,7 @@ import chispa
 from chispa import assert_df_equality
 from dlh_utils.linkage import order_matchkeys,matchkey_join,extract_mk_variables,\
 demographics,demographics_compare,assert_unique_matches,matchkey_counts,\
-matchkey_dataframe
+matchkey_dataframe,deterministic_linkage
 
 pytestmark = pytest.mark.usefixtures("spark")
 
@@ -503,51 +503,61 @@ class TestMatchkeyDataframe(object):
 
         assert_df_equality(intended_df,result_df)
 
+class TestDeterministicLinkage(object):
+    def test_expected(self,spark):
 
-# unable to do pytest on the following code as function 'deterministic_linkage()'
-# is missing the argument 'out_dir'
-#
-#    df_l = spark.createDataFrame(
-#        (pd.DataFrame({
-#            "id_l": [-1, -2, -3],
-#            "first_name": ['AMY', 'AMY', 'AMY'],
-#            "last_name": ['SMITH', 'SMITH', 'SMITH'],
-#            "date_of_birth": ['a', None, 'b'],
-#            "uprn": ['a', 'b', None],
-#            "sex": ['F', 'F', 'F']
-#        })))
-#
-#    df_r = spark.createDataFrame(
-#        (pd.DataFrame({
-#            "id_r": [-1, -2, -3],
-#            "first_name": ['AMY', 'AMY', 'AMY'],
-#            "last_name": ['SMITH', 'SMITH', 'SMITH'],
-#            "date_of_birth": ['a', None, 'b'],
-#            "uprn": ['a', 'b', None],
-#            "sex": ['F', 'F', 'F']
-#        })))
-#
-#    mks = [
-#        [
-#            df_l['first_name'] == df_r['first_name'],
-#            df_l['last_name'] == df_r['last_name'],
-#            df_l['sex'] == df_r['sex'],
-#            df_l['uprn'] == df_r['uprn'],
-#            df_l['date_of_birth'] == df_r['date_of_birth'],
-#        ],
-#        [
-#            df_l['first_name'] == df_r['first_name'],
-#            df_l['last_name'] == df_r['last_name'],
-#            df_l['sex'] == df_r['sex'],
-#            df_l['uprn'] == df_r['uprn'],
-#        ],
-#        [
-#            df_l['first_name'] == df_r['first_name'],
-#            df_l['last_name'] == df_r['last_name'],
-#            df_l['sex'] == df_r['sex'],
-#            df_l['date_of_birth'] == df_r['date_of_birth'],
-#        ],
-#    ]
-#
-#    assert (li.deterministic_linkage(df_l, df_r, 'id_l', 'id_r', mks)
-#            .where(F.col('id_l') != F.col('id_r'))).count() == 0
+      right_df = spark.createDataFrame(
+          (
+              pd.DataFrame(
+                  {
+                      "firstname": ["Alan", "Betty", "Claire", "Claire", "Elin"],
+                      "lastname": ["Jones", "Jones", "Smith", "Jones", "Evans"],
+                      "numeric": [1, 2, 2, 4, 5],
+                      "id1": [1, 2, 3, 4, 5]
+                  }
+              )
+          )
+      )
+
+      left_df = spark.createDataFrame(
+          (
+              pd.DataFrame(
+                  {
+                      "firstname": ["Alan", "Alan", "Betty", "Barry", "Claire", "David", "Emma"],
+                      "lastname": ["Jones", "Smith", "James", "Jones", "Smith", "Jones", "Evans"],
+                      "numeric": [1, 2, 2, 3, 3, 3, 3], 
+                      "id2": [11, 12, 13, 14, 15, 16, 17]
+                  }
+              )
+          )
+      )
+
+      intended_df = spark.createDataFrame(
+        pd.DataFrame(
+            {
+                "id1": [2, 5],
+                "id2": [13, 17],
+                "matchkey": [1, 2]
+            }
+        ),
+        StructType(
+          [
+              StructField("id1", LongType(), True),
+              StructField("id2", LongType(), True),
+              StructField("matchkey", IntegerType(), False),
+          ]
+        )
+      )
+      matchkey = [
+        [right_df.firstname == left_df.firstname],
+        [right_df.lastname == left_df.lastname]  
+      ]
+      result_df = deterministic_linkage(
+        right_df, left_df, 
+        "id1", "id2",
+        matchkey, 
+        None
+      )
+      assert_df_equality(intended_df, result_df, )
+      
+


### PR DESCRIPTION
The deterministic_linkage function takes a parameter `out_dir` that's used to save the linkage in a parquet file. This makes testing awkward.

This change causes deterministic_linkage to interpret `out_dir=None` (which would previously have produced an error) to mean the parquet steps should be skipped, with each step being performed in memory only. Apart from this there should be no functional difference between this version and the previous one.

This has also enabled me to add a basic a unit test.